### PR TITLE
fix: whitespace bug in edge formatting for route name

### DIFF
--- a/src/languages/edge/formatters/edge_formatter.ts
+++ b/src/languages/edge/formatters/edge_formatter.ts
@@ -47,6 +47,9 @@ class EdgeFormatter {
     )
 
     output = inputText.replace(/url\(\"(\s*)/g, 'url("')
+
+    output = output.replace(/route\((\"|\')(\s*)/g, 'route($1')
+
     return output.trim()
   }
 }


### PR DESCRIPTION
## Proposed changes

Add a new line to `edge_formatter` to remove whitespace for the `route` helper.
See the issue here: [Whitespace bug in edge formatting for route name](https://github.com/Julien-R44/adonis-vscode-extension/issues/23)

## Types of changes

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x ] I have read the [CONTRIBUTING](https://github.com/Julien-R44/adonis-vscode-ace/blob/master/.github/CONTRIBUTING.md) doc
- [ x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
